### PR TITLE
Added wildcard for container ID

### DIFF
--- a/docker/docker_test.go
+++ b/docker/docker_test.go
@@ -232,14 +232,14 @@ func TestCollectMetricsWildcard(t *testing.T) {
 			mockTools.On("GetValueByNamespace", mock.AnythingOfType("*cgroups.Stats"), mock.Anything).Return(43)
 
 			d := &docker{
-				stats:          stats,
-				client:         mockClient,
-				tools:          mockTools,
+				stats:  stats,
+				client: mockClient,
+				tools:  mockTools,
 				containersInfo: []ContainerInfo{
 					ContainerInfo{Id: longDockerId1},
 					ContainerInfo{Id: longDockerId2}},
-				groupWrap:      mockWrapper,
-				hostname:       "",
+				groupWrap: mockWrapper,
+				hostname:  "",
 			}
 
 			Convey("When CollectMetric is called", func() {


### PR DESCRIPTION
Addresses #8

`docker ps`
```
CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
7720efd76bb8        ubuntu              "/bin/bash"         35 minutes ago      Up 35 minutes                           prickly_spence
ad5221e8ae73        ubuntu              "/bin/bash"         36 minutes ago      Up 36 minutes                           suspicious_mirzakhani
```

`snapctl metric list`
```
NAMESPACE 										 VERSIONS
/intel/linux/docker/*/blkio_stats/io_service_bytes_recursive/0/major 			 1
/intel/linux/docker/*/blkio_stats/io_service_bytes_recursive/0/op 			 1
/intel/linux/docker/*/blkio_stats/io_service_bytes_recursive/0/value 			 1
/intel/linux/docker/*/blkio_stats/io_service_bytes_recursive/1/major 			 1
/intel/linux/docker/*/blkio_stats/io_service_bytes_recursive/1/op 			 1
/intel/linux/docker/*/blkio_stats/io_service_bytes_recursive/2/major 			 1
/intel/linux/docker/*/blkio_stats/io_service_bytes_recursive/2/op 			 1
/intel/linux/docker/*/blkio_stats/io_service_bytes_recursive/3/major 			 1
/intel/linux/docker/*/blkio_stats/io_service_bytes_recursive/3/op 			 1
/intel/linux/docker/*/blkio_stats/io_service_bytes_recursive/3/value 			 1
/intel/linux/docker/*/blkio_stats/io_service_bytes_recursive/4/major 			 1
/intel/linux/docker/*/blkio_stats/io_service_bytes_recursive/4/op 			 1
/intel/linux/docker/*/blkio_stats/io_service_bytes_recursive/4/value 			 1
/intel/linux/docker/*/blkio_stats/io_serviced_recursive/0/major 			 1
/intel/linux/docker/*/blkio_stats/io_serviced_recursive/0/op 				 1
/intel/linux/docker/*/blkio_stats/io_serviced_recursive/0/value 			 1
/intel/linux/docker/*/blkio_stats/io_serviced_recursive/1/major 			 1
/intel/linux/docker/*/blkio_stats/io_serviced_recursive/1/op 				 1
/intel/linux/docker/*/blkio_stats/io_serviced_recursive/2/major 			 1
/intel/linux/docker/*/blkio_stats/io_serviced_recursive/2/op 				 1
/intel/linux/docker/*/blkio_stats/io_serviced_recursive/3/major 			 1
/intel/linux/docker/*/blkio_stats/io_serviced_recursive/3/op 				 1
/intel/linux/docker/*/blkio_stats/io_serviced_recursive/3/value 			 1
/intel/linux/docker/*/blkio_stats/io_serviced_recursive/4/major 			 1
/intel/linux/docker/*/blkio_stats/io_serviced_recursive/4/op 				 1
/intel/linux/docker/*/blkio_stats/io_serviced_recursive/4/value 			 1
/intel/linux/docker/*/cpu_stats/cpu_usage/percpu_usage/0 				 1
/intel/linux/docker/*/cpu_stats/cpu_usage/percpu_usage/1 				 1
/intel/linux/docker/*/cpu_stats/cpu_usage/percpu_usage/2 				 1
/intel/linux/docker/*/cpu_stats/cpu_usage/percpu_usage/3 				 1
/intel/linux/docker/*/cpu_stats/cpu_usage/total_usage 					 1
/intel/linux/docker/*/cpu_stats/cpu_usage/usage_in_kernelmode 				 1
/intel/linux/docker/*/cpu_stats/cpu_usage/usage_in_usermode 				 1
/intel/linux/docker/*/hugetlb_stats/2MB/failcnt 					 1
/intel/linux/docker/*/memory_stats/cache 						 1
/intel/linux/docker/*/memory_stats/kernel_usage/failcnt 				 1
/intel/linux/docker/*/memory_stats/stats/active_anon 					 1
/intel/linux/docker/*/memory_stats/stats/active_file 					 1
/intel/linux/docker/*/memory_stats/stats/cache 						 1
/intel/linux/docker/*/memory_stats/stats/hierarchical_memory_limit 			 1
/intel/linux/docker/*/memory_stats/stats/hierarchical_memsw_limit 			 1
/intel/linux/docker/*/memory_stats/stats/inactive_anon 					 1
/intel/linux/docker/*/memory_stats/stats/inactive_file 					 1
/intel/linux/docker/*/memory_stats/stats/mapped_file 					 1
/intel/linux/docker/*/memory_stats/stats/pgfault 					 1
/intel/linux/docker/*/memory_stats/stats/pgmajfault 					 1
/intel/linux/docker/*/memory_stats/stats/pgpgin 					 1
/intel/linux/docker/*/memory_stats/stats/pgpgout 					 1
/intel/linux/docker/*/memory_stats/stats/rss 						 1
/intel/linux/docker/*/memory_stats/stats/rss_huge 					 1
/intel/linux/docker/*/memory_stats/stats/swap 						 1
/intel/linux/docker/*/memory_stats/stats/total_active_anon 				 1
/intel/linux/docker/*/memory_stats/stats/total_active_file 				 1
/intel/linux/docker/*/memory_stats/stats/total_cache 					 1
/intel/linux/docker/*/memory_stats/stats/total_inactive_anon 				 1
/intel/linux/docker/*/memory_stats/stats/total_inactive_file 				 1
/intel/linux/docker/*/memory_stats/stats/total_mapped_file 				 1
/intel/linux/docker/*/memory_stats/stats/total_pgfault 					 1
/intel/linux/docker/*/memory_stats/stats/total_pgmajfault 				 1
/intel/linux/docker/*/memory_stats/stats/total_pgpgin 					 1
/intel/linux/docker/*/memory_stats/stats/total_pgpgout 					 1
/intel/linux/docker/*/memory_stats/stats/total_rss 					 1
/intel/linux/docker/*/memory_stats/stats/total_rss_huge 				 1
/intel/linux/docker/*/memory_stats/stats/total_swap 					 1
/intel/linux/docker/*/memory_stats/stats/total_unevictable 				 1
/intel/linux/docker/*/memory_stats/stats/total_writeback 				 1
/intel/linux/docker/*/memory_stats/stats/unevictable 					 1
/intel/linux/docker/*/memory_stats/stats/writeback 					 1
/intel/linux/docker/*/memory_stats/swap_usage/failcnt 					 1
/intel/linux/docker/*/memory_stats/swap_usage/max_usage 				 1
/intel/linux/docker/*/memory_stats/swap_usage/usage 					 1
/intel/linux/docker/*/memory_stats/usage/failcnt 					 1
/intel/linux/docker/*/memory_stats/usage/max_usage 					 1
/intel/linux/docker/*/memory_stats/usage/usage 						 1
/intel/linux/docker/7720efd76bb8/cpu_stats/cpu_usage/percpu_usage/0 			 1
/intel/linux/docker/7720efd76bb8/cpu_stats/cpu_usage/percpu_usage/1 			 1
/intel/linux/docker/7720efd76bb8/cpu_stats/cpu_usage/percpu_usage/2 			 1
/intel/linux/docker/7720efd76bb8/cpu_stats/cpu_usage/percpu_usage/3 			 1
/intel/linux/docker/7720efd76bb8/cpu_stats/cpu_usage/total_usage 			 1
/intel/linux/docker/7720efd76bb8/cpu_stats/cpu_usage/usage_in_kernelmode 		 1
/intel/linux/docker/7720efd76bb8/cpu_stats/cpu_usage/usage_in_usermode 			 1
/intel/linux/docker/7720efd76bb8/hugetlb_stats/2MB/failcnt 				 1
/intel/linux/docker/7720efd76bb8/memory_stats/cache 					 1
/intel/linux/docker/7720efd76bb8/memory_stats/kernel_usage/failcnt 			 1
/intel/linux/docker/7720efd76bb8/memory_stats/stats/active_anon 			 1
/intel/linux/docker/7720efd76bb8/memory_stats/stats/active_file 			 1
/intel/linux/docker/7720efd76bb8/memory_stats/stats/cache 				 1
/intel/linux/docker/7720efd76bb8/memory_stats/stats/hierarchical_memory_limit 		 1
/intel/linux/docker/7720efd76bb8/memory_stats/stats/hierarchical_memsw_limit 		 1
/intel/linux/docker/7720efd76bb8/memory_stats/stats/inactive_anon 			 1
/intel/linux/docker/7720efd76bb8/memory_stats/stats/inactive_file 			 1
/intel/linux/docker/7720efd76bb8/memory_stats/stats/mapped_file 			 1
/intel/linux/docker/7720efd76bb8/memory_stats/stats/pgfault 				 1
/intel/linux/docker/7720efd76bb8/memory_stats/stats/pgmajfault 				 1
/intel/linux/docker/7720efd76bb8/memory_stats/stats/pgpgin 				 1
/intel/linux/docker/7720efd76bb8/memory_stats/stats/pgpgout 				 1
/intel/linux/docker/7720efd76bb8/memory_stats/stats/rss 				 1
/intel/linux/docker/7720efd76bb8/memory_stats/stats/rss_huge 				 1
/intel/linux/docker/7720efd76bb8/memory_stats/stats/swap 				 1
/intel/linux/docker/7720efd76bb8/memory_stats/stats/total_active_anon 			 1
/intel/linux/docker/7720efd76bb8/memory_stats/stats/total_active_file 			 1
/intel/linux/docker/7720efd76bb8/memory_stats/stats/total_cache 			 1
/intel/linux/docker/7720efd76bb8/memory_stats/stats/total_inactive_anon 		 1
/intel/linux/docker/7720efd76bb8/memory_stats/stats/total_inactive_file 		 1
/intel/linux/docker/7720efd76bb8/memory_stats/stats/total_mapped_file 			 1
/intel/linux/docker/7720efd76bb8/memory_stats/stats/total_pgfault 			 1
/intel/linux/docker/7720efd76bb8/memory_stats/stats/total_pgmajfault 			 1
/intel/linux/docker/7720efd76bb8/memory_stats/stats/total_pgpgin 			 1
/intel/linux/docker/7720efd76bb8/memory_stats/stats/total_pgpgout 			 1
/intel/linux/docker/7720efd76bb8/memory_stats/stats/total_rss 				 1
/intel/linux/docker/7720efd76bb8/memory_stats/stats/total_rss_huge 			 1
/intel/linux/docker/7720efd76bb8/memory_stats/stats/total_swap 				 1
/intel/linux/docker/7720efd76bb8/memory_stats/stats/total_unevictable 			 1
/intel/linux/docker/7720efd76bb8/memory_stats/stats/total_writeback 			 1
/intel/linux/docker/7720efd76bb8/memory_stats/stats/unevictable 			 1
/intel/linux/docker/7720efd76bb8/memory_stats/stats/writeback 				 1
/intel/linux/docker/7720efd76bb8/memory_stats/swap_usage/failcnt 			 1
/intel/linux/docker/7720efd76bb8/memory_stats/swap_usage/max_usage 			 1
/intel/linux/docker/7720efd76bb8/memory_stats/swap_usage/usage 				 1
/intel/linux/docker/7720efd76bb8/memory_stats/usage/failcnt 				 1
/intel/linux/docker/7720efd76bb8/memory_stats/usage/max_usage 				 1
/intel/linux/docker/7720efd76bb8/memory_stats/usage/usage 				 1
/intel/linux/docker/ad5221e8ae73/blkio_stats/io_service_bytes_recursive/0/major 	 1
/intel/linux/docker/ad5221e8ae73/blkio_stats/io_service_bytes_recursive/0/op 		 1
/intel/linux/docker/ad5221e8ae73/blkio_stats/io_service_bytes_recursive/0/value 	 1
/intel/linux/docker/ad5221e8ae73/blkio_stats/io_service_bytes_recursive/1/major 	 1
/intel/linux/docker/ad5221e8ae73/blkio_stats/io_service_bytes_recursive/1/op 		 1
/intel/linux/docker/ad5221e8ae73/blkio_stats/io_service_bytes_recursive/2/major 	 1
/intel/linux/docker/ad5221e8ae73/blkio_stats/io_service_bytes_recursive/2/op 		 1
/intel/linux/docker/ad5221e8ae73/blkio_stats/io_service_bytes_recursive/3/major 	 1
/intel/linux/docker/ad5221e8ae73/blkio_stats/io_service_bytes_recursive/3/op 		 1
/intel/linux/docker/ad5221e8ae73/blkio_stats/io_service_bytes_recursive/3/value 	 1
/intel/linux/docker/ad5221e8ae73/blkio_stats/io_service_bytes_recursive/4/major 	 1
/intel/linux/docker/ad5221e8ae73/blkio_stats/io_service_bytes_recursive/4/op 		 1
/intel/linux/docker/ad5221e8ae73/blkio_stats/io_service_bytes_recursive/4/value 	 1
/intel/linux/docker/ad5221e8ae73/blkio_stats/io_serviced_recursive/0/major 		 1
/intel/linux/docker/ad5221e8ae73/blkio_stats/io_serviced_recursive/0/op 		 1
/intel/linux/docker/ad5221e8ae73/blkio_stats/io_serviced_recursive/0/value 		 1
/intel/linux/docker/ad5221e8ae73/blkio_stats/io_serviced_recursive/1/major 		 1
/intel/linux/docker/ad5221e8ae73/blkio_stats/io_serviced_recursive/1/op 		 1
/intel/linux/docker/ad5221e8ae73/blkio_stats/io_serviced_recursive/2/major 		 1
/intel/linux/docker/ad5221e8ae73/blkio_stats/io_serviced_recursive/2/op 		 1
/intel/linux/docker/ad5221e8ae73/blkio_stats/io_serviced_recursive/3/major 		 1
/intel/linux/docker/ad5221e8ae73/blkio_stats/io_serviced_recursive/3/op 		 1
/intel/linux/docker/ad5221e8ae73/blkio_stats/io_serviced_recursive/3/value 		 1
/intel/linux/docker/ad5221e8ae73/blkio_stats/io_serviced_recursive/4/major 		 1
/intel/linux/docker/ad5221e8ae73/blkio_stats/io_serviced_recursive/4/op 		 1
/intel/linux/docker/ad5221e8ae73/blkio_stats/io_serviced_recursive/4/value 		 1
/intel/linux/docker/ad5221e8ae73/cpu_stats/cpu_usage/percpu_usage/0 			 1
/intel/linux/docker/ad5221e8ae73/cpu_stats/cpu_usage/percpu_usage/1 			 1
/intel/linux/docker/ad5221e8ae73/cpu_stats/cpu_usage/percpu_usage/2 			 1
/intel/linux/docker/ad5221e8ae73/cpu_stats/cpu_usage/percpu_usage/3 			 1
/intel/linux/docker/ad5221e8ae73/cpu_stats/cpu_usage/total_usage 			 1
/intel/linux/docker/ad5221e8ae73/cpu_stats/cpu_usage/usage_in_kernelmode 		 1
/intel/linux/docker/ad5221e8ae73/cpu_stats/cpu_usage/usage_in_usermode 			 1
/intel/linux/docker/ad5221e8ae73/hugetlb_stats/2MB/failcnt 				 1
/intel/linux/docker/ad5221e8ae73/memory_stats/cache 					 1
/intel/linux/docker/ad5221e8ae73/memory_stats/kernel_usage/failcnt 			 1
/intel/linux/docker/ad5221e8ae73/memory_stats/stats/active_anon 			 1
/intel/linux/docker/ad5221e8ae73/memory_stats/stats/active_file 			 1
/intel/linux/docker/ad5221e8ae73/memory_stats/stats/cache 				 1
/intel/linux/docker/ad5221e8ae73/memory_stats/stats/hierarchical_memory_limit 		 1
/intel/linux/docker/ad5221e8ae73/memory_stats/stats/hierarchical_memsw_limit 		 1
/intel/linux/docker/ad5221e8ae73/memory_stats/stats/inactive_anon 			 1
/intel/linux/docker/ad5221e8ae73/memory_stats/stats/inactive_file 			 1
/intel/linux/docker/ad5221e8ae73/memory_stats/stats/mapped_file 			 1
/intel/linux/docker/ad5221e8ae73/memory_stats/stats/pgfault 				 1
/intel/linux/docker/ad5221e8ae73/memory_stats/stats/pgmajfault 				 1
/intel/linux/docker/ad5221e8ae73/memory_stats/stats/pgpgin 				 1
/intel/linux/docker/ad5221e8ae73/memory_stats/stats/pgpgout 				 1
/intel/linux/docker/ad5221e8ae73/memory_stats/stats/rss 				 1
/intel/linux/docker/ad5221e8ae73/memory_stats/stats/rss_huge 				 1
/intel/linux/docker/ad5221e8ae73/memory_stats/stats/swap 				 1
/intel/linux/docker/ad5221e8ae73/memory_stats/stats/total_active_anon 			 1
/intel/linux/docker/ad5221e8ae73/memory_stats/stats/total_active_file 			 1
/intel/linux/docker/ad5221e8ae73/memory_stats/stats/total_cache 			 1
/intel/linux/docker/ad5221e8ae73/memory_stats/stats/total_inactive_anon 		 1
/intel/linux/docker/ad5221e8ae73/memory_stats/stats/total_inactive_file 		 1
/intel/linux/docker/ad5221e8ae73/memory_stats/stats/total_mapped_file 			 1
/intel/linux/docker/ad5221e8ae73/memory_stats/stats/total_pgfault 			 1
/intel/linux/docker/ad5221e8ae73/memory_stats/stats/total_pgmajfault 			 1
/intel/linux/docker/ad5221e8ae73/memory_stats/stats/total_pgpgin 			 1
/intel/linux/docker/ad5221e8ae73/memory_stats/stats/total_pgpgout 			 1
/intel/linux/docker/ad5221e8ae73/memory_stats/stats/total_rss 				 1
/intel/linux/docker/ad5221e8ae73/memory_stats/stats/total_rss_huge 			 1
/intel/linux/docker/ad5221e8ae73/memory_stats/stats/total_swap 				 1
/intel/linux/docker/ad5221e8ae73/memory_stats/stats/total_unevictable 			 1
/intel/linux/docker/ad5221e8ae73/memory_stats/stats/total_writeback 			 1
/intel/linux/docker/ad5221e8ae73/memory_stats/stats/unevictable 			 1
/intel/linux/docker/ad5221e8ae73/memory_stats/stats/writeback 				 1
/intel/linux/docker/ad5221e8ae73/memory_stats/swap_usage/failcnt 			 1
/intel/linux/docker/ad5221e8ae73/memory_stats/swap_usage/max_usage 			 1
/intel/linux/docker/ad5221e8ae73/memory_stats/swap_usage/usage 				 1
/intel/linux/docker/ad5221e8ae73/memory_stats/usage/failcnt 				 1
/intel/linux/docker/ad5221e8ae73/memory_stats/usage/max_usage 				 1
/intel/linux/docker/ad5221e8ae73/memory_stats/usage/usage 				 1
```
`task create -t examples/tasks/docker-file.json`

`tail -f /tmp/snap-docker-file.log`
```
2015-12-02 23:15:27.054442993 -0800 PST|[intel linux docker 7720efd76bb8 memory_stats usage usage]|536576|derhorizont/7720efd76bb8
2015-12-02 23:15:27.057902413 -0800 PST|[intel linux docker ad5221e8ae73 memory_stats usage usage]|4718592|derhorizont/ad5221e8ae73
2015-12-02 23:15:27.061082189 -0800 PST|[intel linux docker ad5221e8ae73 cpu_stats cpu_usage total_usage]|36801420|derhorizont/ad5221e8ae73
2015-12-02 23:15:27.067346314 -0800 PST|[intel linux docker 7720efd76bb8 memory_stats stats total_cache]|32768|derhorizont/7720efd76bb8
2015-12-02 23:15:27.071050029 -0800 PST|[intel linux docker ad5221e8ae73 memory_stats stats total_cache]|4235264|derhorizont/ad5221e8ae73
2015-12-02 23:15:28.054831555 -0800 PST|[intel linux docker 7720efd76bb8 memory_stats usage usage]|536576|derhorizont/7720efd76bb8
2015-12-02 23:15:28.058264897 -0800 PST|[intel linux docker ad5221e8ae73 memory_stats usage usage]|4718592|derhorizont/ad5221e8ae73
2015-12-02 23:15:28.06378469 -0800 PST|[intel linux docker ad5221e8ae73 cpu_stats cpu_usage total_usage]|36801420|derhorizont/ad5221e8ae73
2015-12-02 23:15:28.067595037 -0800 PST|[intel linux docker 7720efd76bb8 memory_stats stats total_cache]|32768|derhorizont/7720efd76bb8
2015-12-02 23:15:28.070943944 -0800 PST|[intel linux docker ad5221e8ae73 memory_stats stats total_cache]|4235264|derhorizont/ad5221e8ae73
2015-12-02 23:15:29.0537833 -0800 PST|[intel linux docker 7720efd76bb8 memory_stats usage usage]|536576|derhorizont/7720efd76bb8
2015-12-02 23:15:29.057250672 -0800 PST|[intel linux docker ad5221e8ae73 memory_stats usage usage]|4718592|derhorizont/ad5221e8ae73
```

```json
{
    "version": 1,
    "schedule": {
        "type": "simple",
        "interval": "1s"
    },
    "workflow": {
        "collect": {
            "metrics": {
                "/intel/linux/docker/ad5221e8ae73/cpu_stats/cpu_usage/total_usage":{},
                "/intel/linux/docker/ad5221e8ae73/memory_stats/usage/usage": {},
                "/intel/linux/docker/7720efd76bb8/memory_stats/usage/usage": {},
                "/intel/linux/docker/*/memory_stats/stats/total_cache": {}
            },
            "config": {
                "/intel/mock": {
                    "user": "root",
                    "password": "secret"
                }
            },
            "process": [
                {
                    "plugin_name": "passthru",                    
                    "process": null,
                    "publish": [
                        {
                            "plugin_name": "file",                            
                            "config": {
                                "file": "/tmp/snap-docker-file.log"
                            }
                        }
                    ]
                }
            ]
        }
    }
}
```