### PR TITLE
Updated Snap binaries in large tests and in example

### DIFF
--- a/examples/tasks/README.md
+++ b/examples/tasks/README.md
@@ -25,7 +25,7 @@ Run the script `./run-dockerception.sh`.
 - [docker-compose.yml](docker-compose.yml)
     - A docker compose file which defines the "docker" container.
 - [docker-file.sh](docker-file.sh)
-    - Downloads `snapd`, `snapctl`, `snap-plugin-publisher-file`,
+    - Downloads `snapteld`, `snaptel`, `snap-plugin-publisher-file`,
     `snap-plugin-collector-docker` and starts the task 
     [tasks/docker-file.json](tasks/docker-file.json).
 - [.setup.sh](.setup.sh)

--- a/examples/tasks/docker-file.sh
+++ b/examples/tasks/docker-file.sh
@@ -15,8 +15,8 @@ TMPDIR=${TMPDIR:-"/tmp"}
 PLUGIN_PATH=${PLUGIN_PATH:-"${TMPDIR}/snap/plugins"}
 mkdir -p $PLUGIN_PATH
 
-install_snap
-snapd -t ${SNAP_TRUST_LEVEL} -l ${SNAP_LOG_LEVEL} &
+init_snap
+snapteld -t ${SNAP_TRUST_LEVEL} -l ${SNAP_LOG_LEVEL} &
 
 _info "Get latest plugins"
 (cd $PLUGIN_PATH && curl -sfLSO http://snap.ci.snap-telemetry.io/plugins/snap-plugin-publisher-file/master/latest/linux/x86_64/snap-plugin-publisher-file && chmod 755 snap-plugin-publisher-file)
@@ -24,31 +24,31 @@ _info "Get latest plugins"
 
 SNAP_FLAG=0
 
-# this block will wait check if snapctl and snapd are loaded before the plugins are loaded and the task is started
+# this block will wait check if snaptel and snapteld are loaded before the plugins are loaded and the task is started
  for i in `seq 1 5`; do
-             if [[ -f /usr/local/bin/snapctl && -f /usr/local/bin/snapd ]];
+             if [[ -f /usr/local/bin/snaptel && -f /usr/local/sbin/snapteld ]];
                 then
 
                     _info "loading plugins"
-                    snapctl plugin load "${PLUGIN_PATH}/snap-plugin-publisher-file"
-                    snapctl plugin load "${PLUGIN_PATH}/snap-plugin-collector-docker"
+                    snaptel plugin load "${PLUGIN_PATH}/snap-plugin-publisher-file"
+                    snaptel plugin load "${PLUGIN_PATH}/snap-plugin-collector-docker"
                     
                     _info "creating and starting a task"
-                    snapctl task create -t "${__dir}/docker-file.json"
+                    snaptel task create -t "${__dir}/docker-file.json"
 
                     SNAP_FLAG=1
 
                     break
              fi 
         
-        _info "snapctl and/or snapd are unavailable, sleeping for 3 seconds" 
+        _info "snaptel and/or snapteld are unavailable, sleeping for 3 seconds"
         sleep 3
 done 
 
 
-# check if snapctl/snapd have loaded
+# check if snaptel/snapteld have loaded
 if [ $SNAP_FLAG -eq 0 ]
     then
-     echo "Could not load snapctl or snapd"
+     echo "Could not load snaptel or snapteld"
      exit 1
 fi

--- a/examples/tasks/run-dockerception.sh
+++ b/examples/tasks/run-dockerception.sh
@@ -13,9 +13,9 @@ PLUGIN_SRC="${PLUGIN_SRC:-"$(cd "$(dirname "$0")"/../../ && pwd)"}"
 PLUGIN_DEST="${PLUGIN_DEST:-$PLUGIN_SRC}"
 
 # docker-file.sh will download plugins, starts snap, load plugins and start a task
-DEFAULT_SCRIPT="${PLUGIN_DEST}/examples/tasks/docker-file.sh && printf \"\n\nhint: type 'snapctl task list'\ntype 'exit' when your done\n\n\" && bash"
+DEFAULT_SCRIPT="${PLUGIN_DEST}/examples/tasks/docker-file.sh && printf \"\n\nhint: type 'snaptel task list'\ntype 'exit' when your done\n\n\" && bash"
 RUN_SCRIPT="export SNAP_VERSION=${SNAP_VERSION} && export PROCFS_MOUNT=${PROCFS_MOUNT} && ${RUN_SCRIPT:-$DEFAULT_SCRIPT}"
 
 
-docker run -i --name dockerception -v /proc:${PROCFS_MOUNT} -v /var/lib/docker:/var/lib/docker -v /sys/fs/cgroup:/sys/fs/cgroup  -v /var/run/docker.sock:/var/run/docker.sock -v ${PLUGIN_SRC}:${PLUGIN_DEST} intelsdi/snap:alpine bash -c "$RUN_SCRIPT"
+docker run -i --name dockerception -v /proc:${PROCFS_MOUNT} -v /var/lib/docker:/var/lib/docker -v /sys/fs/cgroup:/sys/fs/cgroup  -v /var/run/docker.sock:/var/run/docker.sock -v ${PLUGIN_SRC}:${PLUGIN_DEST} intelsdi/snap:alpine_test bash -c "$RUN_SCRIPT"
 docker rm dockerception

--- a/scripts/large_tests.sh
+++ b/scripts/large_tests.sh
@@ -19,7 +19,7 @@ sleep 20
 # begin assertions
 return_code=0
 echo -n "[task is running] "
-task_list=$(snapctl task list | tail -1)
+task_list=$(snaptel task list | tail -1)
 if echo $task_list | grep -q Running; then
     echo "ok"
 else 


### PR DESCRIPTION
Summary of changes:
- snapd changed to snapteld in large tests and in example
- snapctl changed to snaptel in large tests and in example
- init_snap used in docker to download proper binaries

@intelsdi-x/plugin-maintainers 