### PR TITLE
Fixes #44 panic when getting disk usage

### DIFF
--- a/fs/fs.go
+++ b/fs/fs.go
@@ -367,7 +367,11 @@ func (self *RealFsInfo) updateContainerImagesPath(label string, mounts []*mount.
 }
 
 func diskUsage(dir string) (uint64, error) {
-	out, _ := exec.Command("du", "-s", dir).Output()
+	out, err := exec.Command("du", "-sx", dir).Output()
+	if err != nil {
+		return 0, err
+	}
+
 	val := strings.Fields(string(out))[0]
 	size, err := strconv.ParseUint(val, 10, 64)
 	if err != nil {


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
Fixes #44

Summary of changes:
- added `-x` option for disk usage call
- error handling on calling `du` added

@intelsdi-x/plugin-maintainers 