### PR TITLE
(SDI-2268) Expose cpuset metrics per container

### DIFF
--- a/METRICS.md
+++ b/METRICS.md
@@ -105,6 +105,12 @@ memory_stats/stats/total_rss_huge | uint64 | The total number of bytes of anonym
 memory_stats/stats/total_swap | uint64 | The total number of bytes of swap usage <sup>(1)</sup>
 memory_stats/stats/total_unevictable | uint64 | The total number of bytes of memory that cannot be reclaimed <sup>(1)</sup>
 memory_stats/stats/total_writeback | uint64 | The total number of bytes of file/anon cache that are queued for syncing to disk <sup>(1)</sup>
+cpuset/cpu_exclusive | uint64 | contains a flag (0 or 1) that specifies whether cpusets other than this one and its parents and children can share the CPUs specified for this cpuset
+cpuset/memory_exclusive | uint64 | contains a flag (0 or 1) that specifies whether other cpusets can share the memory nodes specified for the cpuset
+cpuset/memory_migrate | uint64 | contains a flag (0 or 1) that specifies whether a page in memory should migrate to a new node if the values in cpuset.mems change
+cpuset/cpus | string | specifies the CPUs that tasks in this cgroup are permitted to access
+cpuset/mems | string | specifies the memory nodes that tasks in this cgroup are permitted to access
+shares/cpu | uint64 | contains an integer value that specifies a relative share of CPU time available to the tasks in a cgroup
 
 <sup>(1)</sup> Hierarchical version of cgroups counter which in addition to the cgroup's own value includes the sum of all hierarchical children's values
 

--- a/client/client.go
+++ b/client/client.go
@@ -137,8 +137,21 @@ func (dc *DockerClient) GetStatsFromContainer(id string, collectFs bool) (*wrapp
 			fmt.Fprintln(os.Stderr, "Cannot found subsystem path for cgroup=", cg, " for container id=", container)
 			continue
 		}
-		// get cgroup stats for given docker
-		err = stat.GetStats(groupPath, stats.CgroupStats)
+
+		switch cg {
+		case "cpuset":
+			cpuset := wrapper.CpuSet{}
+			// get cpuset group stats
+			err = cpuset.GetExtendedStats(groupPath, stats.CgroupsExtended)
+		case "shares":
+			// get cpu.shares stats
+			shares := wrapper.Shares{}
+			err = shares.GetExtendedStats(groupPath, stats.CgroupsExtended)
+		default:
+			// get cgroup stats for given docker
+			err = stat.GetStats(groupPath, stats.CgroupStats)
+		}
+
 		if err != nil {
 			// just log about it
 			if isHost(id) {
@@ -258,6 +271,11 @@ func (dc *DockerClient) ListContainersAsMap() (map[string]docker.APIContainers, 
 func getSubsystemPath(subsystem string, id string) (string, error) {
 	var subsystemPath string
 	systemSlice := "system.slice"
+	// hack for finding proper mount point for shares
+	// cpu shares are part of cpu group, but openlibcontainers does not support it
+	if subsystem == "shares" {
+		subsystem = "cpu"
+	}
 	groupPath, err := cgroups.FindCgroupMountpoint(subsystem)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "[WARNING] Could not find mount point for %v\n", subsystem)

--- a/client/client.go
+++ b/client/client.go
@@ -113,7 +113,7 @@ func (dc *DockerClient) GetStatsFromContainer(id string, collectFs bool) (*wrapp
 		workingSet uint64
 
 		container = &docker.Container{}
-		groupWrap = wrapper.Cgroups2Stats // wrapper for cgroup name and interface for stats extraction
+		groupWrap = wrapper.CgroupsToStats // wrapper for cgroup name and interface for stats extraction
 		stats     = wrapper.NewStatistics()
 	)
 

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -45,7 +45,7 @@ const (
 	// namespace plugin name
 	NS_PLUGIN = "docker"
 	// version of plugin
-	VERSION = 4
+	VERSION = 5
 
 	// each metric starts with prefix "/intel/docker/<docker_id>"
 	lengthOfNsPrefix = 3

--- a/scripts/config/docker-deployment.yml
+++ b/scripts/config/docker-deployment.yml
@@ -16,10 +16,6 @@ spec:
               env:
                 - name: SNAP_VERSION
                   value: "latest"
-                - name: PLUGIN_SRC
-                  value: /src
-                - name: RUN_SCRIPT
-                  value: "\"/src/scripts/large_tests.sh\""
               imagePullPolicy: "IfNotPresent"
               securityContext:
                 privileged: true

--- a/wrapper/wrapper.go
+++ b/wrapper/wrapper.go
@@ -63,9 +63,10 @@ type Statistics struct {
 	Filesystem      map[string]FilesystemInterface `json:"filesystem"`
 }
 
-// CgroupsExtended holds additional group statsistics like cpuset and shares
+// CgroupsExtended holds additional group statistics like cpuset and shares
+// These stats are not supported by libcontainers lib
 type CgroupExtended struct {
-	Cpuset CpuSet `json:"cpuset"`
+	CpuSet CpuSet `json:"cpuset"`
 	Shares Shares `json:"shares"`
 }
 
@@ -92,20 +93,20 @@ func (cs *CpuSet) GetExtendedStats(path string, ext *CgroupExtended) error {
 		return err
 	}
 
-	ext.Cpuset.Cpus = string(cpus)
-	ext.Cpuset.Mems = string(mems)
+	ext.CpuSet.Cpus = string(cpus)
+	ext.CpuSet.Mems = string(mems)
 
-	ext.Cpuset.MemoryMigrate, err = strconv.ParseUint(strings.Trim(string(memmig), "\n"), 10, 64)
+	ext.CpuSet.MemoryMigrate, err = strconv.ParseUint(strings.Trim(string(memmig), "\n"), 10, 64)
 	if err != nil {
 		return err
 	}
 
-	ext.Cpuset.CpuExclusive, err = strconv.ParseUint(strings.Trim(string(cpuexc), "\n"), 10, 64)
+	ext.CpuSet.CpuExclusive, err = strconv.ParseUint(strings.Trim(string(cpuexc), "\n"), 10, 64)
 	if err != nil {
 		return err
 	}
 
-	ext.Cpuset.MemoryExclusive, err = strconv.ParseUint(strings.Trim(string(memexc), "\n"), 10, 64)
+	ext.CpuSet.MemoryExclusive, err = strconv.ParseUint(strings.Trim(string(memexc), "\n"), 10, 64)
 	if err != nil {
 		return err
 	}

--- a/wrapper/wrapper.go
+++ b/wrapper/wrapper.go
@@ -30,7 +30,7 @@ import (
 )
 
 // Cgroups2Stats holds pointer to appropriate cgroup type (defined in lib `opencontainers`) under cgroup name as a key
-var Cgroups2Stats = map[string]Stats{
+var CgroupsToStats = map[string]Stats{
 	"cpuset":  &CpuSet{},
 	"shares":  &Shares{},
 	"cpu":     &fs.CpuGroup{},

--- a/wrapper/wrapper.go
+++ b/wrapper/wrapper.go
@@ -20,13 +20,19 @@ limitations under the License.
 package wrapper
 
 import (
+	"io/ioutil"
+	"path/filepath"
+	"strconv"
+	"strings"
+
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/cgroups/fs"
 )
 
 // Cgroups2Stats holds pointer to appropriate cgroup type (defined in lib `opencontainers`) under cgroup name as a key
 var Cgroups2Stats = map[string]Stats{
-	"cpuset":  &fs.CpusetGroup{},
+	"cpuset":  &CpuSet{},
+	"shares":  &Shares{},
 	"cpu":     &fs.CpuGroup{},
 	"cpuacct": &fs.CpuacctGroup{},
 	"memory":  &fs.MemoryGroup{},
@@ -50,10 +56,101 @@ type Specification struct {
 
 // Statistics holds all available statistics: network, tcp/tcp6, cgroups and filesystem
 type Statistics struct {
-	Network     []NetworkInterface             `json:"network"`
-	Connection  TcpInterface                   `json:"connection"` //TCP, TCP6 connection stats
-	CgroupStats *cgroups.Stats                 `json:"cgroups"`
-	Filesystem  map[string]FilesystemInterface `json:"filesystem"`
+	Network         []NetworkInterface             `json:"network"`
+	Connection      TcpInterface                   `json:"connection"` //TCP, TCP6 connection stats
+	CgroupStats     *cgroups.Stats                 `json:"cgroups"`
+	CgroupsExtended *CgroupExtended                `json:"cgroups_extended"`
+	Filesystem      map[string]FilesystemInterface `json:"filesystem"`
+}
+
+// CgroupsExtended holds additional group statsistics like cpuset and shares
+type CgroupExtended struct {
+	Cpuset CpuSet `json:"cpuset"`
+	Shares Shares `json:"shares"`
+}
+
+// GetExtendedStats extracts CPUs and memory nodes a group can access
+func (cs *CpuSet) GetExtendedStats(path string, ext *CgroupExtended) error {
+	cpus, err := ioutil.ReadFile(filepath.Join(path, "cpuset.cpus"))
+	if err != nil {
+		return err
+	}
+	mems, err := ioutil.ReadFile(filepath.Join(path, "cpuset.mems"))
+	if err != nil {
+		return err
+	}
+	memmig, err := ioutil.ReadFile(filepath.Join(path, "cpuset.memory_migrate"))
+	if err != nil {
+		return err
+	}
+	cpuexc, err := ioutil.ReadFile(filepath.Join(path, "cpuset.cpu_exclusive"))
+	if err != nil {
+		return err
+	}
+	memexc, err := ioutil.ReadFile(filepath.Join(path, "cpuset.mem_exclusive"))
+	if err != nil {
+		return err
+	}
+
+	ext.Cpuset.Cpus = string(cpus)
+	ext.Cpuset.Mems = string(mems)
+
+	ext.Cpuset.MemoryMigrate, err = strconv.ParseUint(strings.Trim(string(memmig), "\n"), 10, 64)
+	if err != nil {
+		return err
+	}
+
+	ext.Cpuset.CpuExclusive, err = strconv.ParseUint(strings.Trim(string(cpuexc), "\n"), 10, 64)
+	if err != nil {
+		return err
+	}
+
+	ext.Cpuset.MemoryExclusive, err = strconv.ParseUint(strings.Trim(string(memexc), "\n"), 10, 64)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// GetStats is not used. It is defined only to implement interface for CpuSet as a member of Cgroups2Stats
+// It is temporary solution until openlibcontainers lib provides mechanism to extract cpuset values from cgroups
+func (cs *CpuSet) GetStats(path string, stats *cgroups.Stats) error {
+	return nil
+}
+
+// CpuSet stores information regarding subsystem assignment of individual CPUs and memory nodes
+type CpuSet struct {
+	Cpus            string `json:"cpus"`
+	Mems            string `json:"mems"`
+	MemoryMigrate   uint64 `json:"memory_migrate"`
+	CpuExclusive    uint64 `json:"cpu_exclusive"`
+	MemoryExclusive uint64 `json:"memory_exclusive"`
+}
+
+// Shares stores information regarding relative share of CPU time available to the tasks in a group
+type Shares struct {
+	Cpu uint64 `json:"cpu"`
+}
+
+// GetExtendedStats extracts integer value from cpu.shares file in given group
+func (s *Shares) GetExtendedStats(path string, ext *CgroupExtended) error {
+	cpu, err := ioutil.ReadFile(filepath.Join(path, "cpu.shares"))
+	if err != nil {
+		return err
+	}
+	ext.Shares.Cpu, err = strconv.ParseUint(strings.Trim(string(cpu), "\n"), 10, 64)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// GetStats is not used. It is defined only to implement interface for Shares as a member of Cgroups2Stats
+// It is temporary solution until openlibcontainers lib provides mechanism to extract shares from cgroups
+func (s *Shares) GetStats(path string, stats *cgroups.Stats) error {
+	return nil
 }
 
 // NetworkInterface holds name of network interface and its statistics (rx_bytes, tx_bytes, etc.)
@@ -177,8 +274,9 @@ var listOfMemoryStats = []string{
 // NewStatistics returns pointer to initialized Statistics
 func NewStatistics() *Statistics {
 	return &Statistics{
-		Network:     []NetworkInterface{},
-		CgroupStats: newCgroupsStats(),
+		Network:         []NetworkInterface{},
+		CgroupStats:     newCgroupsStats(),
+		CgroupsExtended: &CgroupExtended{},
 		Connection: TcpInterface{
 			Tcp:  TcpStat{},
 			Tcp6: TcpStat{},

--- a/wrapper/wrapper_test.go
+++ b/wrapper/wrapper_test.go
@@ -33,11 +33,11 @@ func TestWrapperProperDeclaration(t *testing.T) {
 	Convey("Check for proper delcaration of wrapper map", t, func() {
 
 		Convey("Length of map", func() {
-			So(len(Cgroups2Stats), ShouldBeGreaterThan, 0)
+			So(len(CgroupsToStats), ShouldBeGreaterThan, 0)
 		})
 
 		Convey("Each value is of Stats interface type", func() {
-			for _, val := range Cgroups2Stats {
+			for _, val := range CgroupsToStats {
 				_, ok := val.(Stats)
 				So(ok, ShouldBeTrue)
 			}


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
Fixes #47 

Summary of changes:
- cpuset subsystem statistics added
- cpu.shares added
- removed hardcoded paths to plugin source and run script in K8S deployment
- documentation updated

How to verify it:
- small tests
- large tests
- running any task with 

Testing done:
- small tests
- large tests

@intelsdi-x/plugin-maintainers 