### PR TITLE
[WIP] Make docker endpoint configurable

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -39,7 +39,6 @@ import (
 )
 
 const (
-	endpoint         string = "unix:///var/run/docker.sock"
 	dockerVersionKey string = "Version"
 )
 
@@ -68,7 +67,7 @@ type deviceInfo struct {
 }
 
 // NewDockerClient returns dockerClient instance ready for communication with the server endpoint `unix:///var/run/docker.sock`
-func NewDockerClient() (*DockerClient, error) {
+func NewDockerClient(endpoint string) (*DockerClient, error) {
 	client, err := docker.NewClient(endpoint)
 	if err != nil {
 		return nil, fmt.Errorf("Cannot initialize docker client instance with the given server endpoint `%s`, err=%v", endpoint, err)

--- a/examples/configs/config.yml
+++ b/examples/configs/config.yml
@@ -1,0 +1,5 @@
+control:
+  plugins:
+    collector:
+      docker:
+        endpoint: "unix:///var/run/docker.sock"

--- a/examples/tasks/docker-file.json
+++ b/examples/tasks/docker-file.json
@@ -9,7 +9,11 @@
       "metrics": {
         "/intel/docker/*": {}
       },
-      "config": {},
+      "config": {
+        "/intel/docker/*": {
+          "endpoint": "unix:///var/run/docker.sock",
+        }
+      },
       "publish": [
         {
           "plugin_name": "file",

--- a/glide.yaml
+++ b/glide.yaml
@@ -35,6 +35,9 @@ import:
   subpackages:
   - ns
   - str
+- package: github.com/intelsdi-x/snap-plugin-lib-go
+  subpackages:
+  - v1/plugin
 - package: github.com/intelsdi-x/snap
   version: 8163e12d61fcd6f87151a5658da7f718f3785e57
   subpackages:


### PR DESCRIPTION
<!--
If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
Introduces capability to configure docker host from plugin policy config.

Summary of changes:
- new dependency - snap-plugin-lib-go
- docker endpoint being pulled from config with Docker unix socket as default value

How to verify it:
- WIP

Testing done:
- WIP

