### PR TITLE
Labels to tag

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -28,7 +28,7 @@ import (
 	"time"
 
 	log "github.com/Sirupsen/logrus"
-	"github.com/fsouza/go-dockerclient"
+	docker "github.com/fsouza/go-dockerclient"
 	utils "github.com/intelsdi-x/snap-plugin-utilities/ns"
 
 	"github.com/intelsdi-x/snap-plugin-collector-docker/container"
@@ -192,7 +192,6 @@ func (c *collector) CollectMetrics(mts []plugin.Metric) ([]plugin.Metric, error)
 					Timestamp: time.Now(),
 					Namespace: ns,
 					Data:      utils.GetValueByNamespace(c.containers[rid], metricName),
-					Tags:      mt.Tags,
 					Config:    mt.Config,
 					Version:   PLUGIN_VERSION,
 				}
@@ -241,7 +240,6 @@ func (c *collector) CollectMetrics(mts []plugin.Metric) ([]plugin.Metric, error)
 						Timestamp: time.Now(),
 						Namespace: rns,
 						Data:      utils.GetValueByNamespace(c.containers[rid].Stats.Filesystem[device], metricName[1:]),
-						Tags:      mt.Tags,
 						Config:    mt.Config,
 						Version:   PLUGIN_VERSION,
 					}
@@ -274,7 +272,6 @@ func (c *collector) CollectMetrics(mts []plugin.Metric) ([]plugin.Metric, error)
 						Timestamp: time.Now(),
 						Namespace: rns,
 						Data:      c.containers[rid].Specification.Labels[labelKey],
-						Tags:      mt.Tags,
 						Config:    mt.Config,
 						Version:   PLUGIN_VERSION,
 					}
@@ -311,7 +308,6 @@ func (c *collector) CollectMetrics(mts []plugin.Metric) ([]plugin.Metric, error)
 						Timestamp: time.Now(),
 						Namespace: rns,
 						Data:      utils.GetValueByNamespace(ifaceMap[ifaceName], metricName[1:]),
-						Tags:      mt.Tags,
 						Config:    mt.Config,
 						Version:   PLUGIN_VERSION,
 					}
@@ -332,7 +328,6 @@ func (c *collector) CollectMetrics(mts []plugin.Metric) ([]plugin.Metric, error)
 							Timestamp: time.Now(),
 							Namespace: rns,
 							Data:      val,
-							Tags:      mt.Tags,
 							Config:    mt.Config,
 							Version:   PLUGIN_VERSION,
 						}
@@ -351,7 +346,6 @@ func (c *collector) CollectMetrics(mts []plugin.Metric) ([]plugin.Metric, error)
 						Timestamp: time.Now(),
 						Namespace: ns,
 						Data:      c.containers[rid].Stats.Cgroups.CpuStats.CpuUsage.PerCpu[cpuID],
-						Tags:      mt.Tags,
 						Config:    mt.Config,
 						Version:   PLUGIN_VERSION,
 					}
@@ -380,7 +374,6 @@ func (c *collector) CollectMetrics(mts []plugin.Metric) ([]plugin.Metric, error)
 						Timestamp: time.Now(),
 						Namespace: rns,
 						Data:      utils.GetValueByNamespace(c.containers[rid].Stats.Cgroups.HugetlbStats[size], mt.Namespace.Strings()[len(ns)-1:]),
-						Tags:      mt.Tags,
 						Config:    mt.Config,
 						Version:   PLUGIN_VERSION,
 					}
@@ -399,7 +392,6 @@ func (c *collector) CollectMetrics(mts []plugin.Metric) ([]plugin.Metric, error)
 							Timestamp: time.Now(),
 							Namespace: rns,
 							Data:      utils.GetValueByNamespace(imr, mt.Namespace.Strings()[len(ns)-1:]),
-							Tags:      mt.Tags,
 							Config:    mt.Config,
 							Version:   PLUGIN_VERSION,
 						}
@@ -418,7 +410,6 @@ func (c *collector) CollectMetrics(mts []plugin.Metric) ([]plugin.Metric, error)
 						Timestamp: time.Now(),
 						Namespace: ns,
 						Data:      utils.GetValueByNamespace(c.containers[rid].Stats.Cgroups.BlkioStats.IoMergedRecursive[deviceID], mt.Namespace.Strings()[len(ns)-1:]),
-						Tags:      mt.Tags,
 						Config:    mt.Config,
 						Version:   PLUGIN_VERSION,
 					}
@@ -436,7 +427,6 @@ func (c *collector) CollectMetrics(mts []plugin.Metric) ([]plugin.Metric, error)
 							Timestamp: time.Now(),
 							Namespace: rns,
 							Data:      utils.GetValueByNamespace(isbr, mt.Namespace.Strings()[len(ns)-1:]),
-							Tags:      mt.Tags,
 							Config:    mt.Config,
 							Version:   PLUGIN_VERSION,
 						}
@@ -455,7 +445,6 @@ func (c *collector) CollectMetrics(mts []plugin.Metric) ([]plugin.Metric, error)
 						Timestamp: time.Now(),
 						Namespace: ns,
 						Data:      utils.GetValueByNamespace(c.containers[rid].Stats.Cgroups.BlkioStats.IoServiceBytesRecursive[deviceID], mt.Namespace.Strings()[len(ns)-1:]),
-						Tags:      mt.Tags,
 						Config:    mt.Config,
 						Version:   PLUGIN_VERSION,
 					}
@@ -473,7 +462,6 @@ func (c *collector) CollectMetrics(mts []plugin.Metric) ([]plugin.Metric, error)
 							Timestamp: time.Now(),
 							Namespace: rns,
 							Data:      utils.GetValueByNamespace(isr, mt.Namespace.Strings()[len(ns)-1:]),
-							Tags:      mt.Tags,
 							Config:    mt.Config,
 							Version:   PLUGIN_VERSION,
 						}
@@ -492,7 +480,6 @@ func (c *collector) CollectMetrics(mts []plugin.Metric) ([]plugin.Metric, error)
 						Timestamp: time.Now(),
 						Namespace: ns,
 						Data:      utils.GetValueByNamespace(c.containers[rid].Stats.Cgroups.BlkioStats.IoServicedRecursive[deviceID], mt.Namespace.Strings()[len(ns)-1:]),
-						Tags:      mt.Tags,
 						Config:    mt.Config,
 						Version:   PLUGIN_VERSION,
 					}
@@ -510,7 +497,6 @@ func (c *collector) CollectMetrics(mts []plugin.Metric) ([]plugin.Metric, error)
 							Timestamp: time.Now(),
 							Namespace: rns,
 							Data:      utils.GetValueByNamespace(iqr, mt.Namespace.Strings()[len(ns)-1:]),
-							Tags:      mt.Tags,
 							Config:    mt.Config,
 							Version:   PLUGIN_VERSION,
 						}
@@ -529,7 +515,6 @@ func (c *collector) CollectMetrics(mts []plugin.Metric) ([]plugin.Metric, error)
 						Timestamp: time.Now(),
 						Namespace: ns,
 						Data:      utils.GetValueByNamespace(c.containers[rid].Stats.Cgroups.BlkioStats.IoQueuedRecursive[deviceID], mt.Namespace.Strings()[len(ns)-1:]),
-						Tags:      mt.Tags,
 						Config:    mt.Config,
 						Version:   PLUGIN_VERSION,
 					}
@@ -547,7 +532,6 @@ func (c *collector) CollectMetrics(mts []plugin.Metric) ([]plugin.Metric, error)
 							Timestamp: time.Now(),
 							Namespace: rns,
 							Data:      utils.GetValueByNamespace(istr, mt.Namespace.Strings()[len(ns)-1:]),
-							Tags:      mt.Tags,
 							Config:    mt.Config,
 							Version:   PLUGIN_VERSION,
 						}
@@ -566,7 +550,6 @@ func (c *collector) CollectMetrics(mts []plugin.Metric) ([]plugin.Metric, error)
 						Timestamp: time.Now(),
 						Namespace: ns,
 						Data:      utils.GetValueByNamespace(c.containers[rid].Stats.Cgroups.BlkioStats.IoServiceTimeRecursive[deviceID], mt.Namespace.Strings()[len(ns)-1:]),
-						Tags:      mt.Tags,
 						Config:    mt.Config,
 						Version:   PLUGIN_VERSION,
 					}
@@ -584,7 +567,6 @@ func (c *collector) CollectMetrics(mts []plugin.Metric) ([]plugin.Metric, error)
 							Timestamp: time.Now(),
 							Namespace: rns,
 							Data:      utils.GetValueByNamespace(iwtr, mt.Namespace.Strings()[len(ns)-1:]),
-							Tags:      mt.Tags,
 							Config:    mt.Config,
 							Version:   PLUGIN_VERSION,
 						}
@@ -603,7 +585,6 @@ func (c *collector) CollectMetrics(mts []plugin.Metric) ([]plugin.Metric, error)
 						Timestamp: time.Now(),
 						Namespace: ns,
 						Data:      utils.GetValueByNamespace(c.containers[rid].Stats.Cgroups.BlkioStats.IoWaitTimeRecursive[deviceID], mt.Namespace.Strings()[len(ns)-1:]),
-						Tags:      mt.Tags,
 						Config:    mt.Config,
 						Version:   PLUGIN_VERSION,
 					}
@@ -621,7 +602,6 @@ func (c *collector) CollectMetrics(mts []plugin.Metric) ([]plugin.Metric, error)
 							Timestamp: time.Now(),
 							Namespace: rns,
 							Data:      utils.GetValueByNamespace(itr, mt.Namespace.Strings()[len(ns)-1:]),
-							Tags:      mt.Tags,
 							Config:    mt.Config,
 							Version:   PLUGIN_VERSION,
 						}
@@ -640,7 +620,6 @@ func (c *collector) CollectMetrics(mts []plugin.Metric) ([]plugin.Metric, error)
 						Timestamp: time.Now(),
 						Namespace: ns,
 						Data:      utils.GetValueByNamespace(c.containers[rid].Stats.Cgroups.BlkioStats.IoTimeRecursive[deviceID], mt.Namespace.Strings()[len(ns)-1:]),
-						Tags:      mt.Tags,
 						Config:    mt.Config,
 						Version:   PLUGIN_VERSION,
 					}
@@ -658,7 +637,6 @@ func (c *collector) CollectMetrics(mts []plugin.Metric) ([]plugin.Metric, error)
 							Timestamp: time.Now(),
 							Namespace: rns,
 							Data:      utils.GetValueByNamespace(sr, mt.Namespace.Strings()[len(ns)-1:]),
-							Tags:      mt.Tags,
 							Config:    mt.Config,
 							Version:   PLUGIN_VERSION,
 						}
@@ -677,7 +655,6 @@ func (c *collector) CollectMetrics(mts []plugin.Metric) ([]plugin.Metric, error)
 						Timestamp: time.Now(),
 						Namespace: ns,
 						Data:      utils.GetValueByNamespace(c.containers[rid].Stats.Cgroups.BlkioStats.SectorsRecursive[deviceID], mt.Namespace.Strings()[len(ns)-1:]),
-						Tags:      mt.Tags,
 						Config:    mt.Config,
 						Version:   PLUGIN_VERSION,
 					}
@@ -697,11 +674,9 @@ func (c *collector) CollectMetrics(mts []plugin.Metric) ([]plugin.Metric, error)
 		rid := metrics[i].Namespace[2].Value
 		if rid != "root" {
 			// add labels only for docker cointainer, skip the host
-			for labelKey, labelValue := range c.containers[rid].Specification.Labels {
-			metrics[i].Tags[labelKey] = labelValue
-			}
+			metrics[i].Tags = c.containers[rid].Specification.Labels
 		}
-		
+
 	}
 
 	return metrics, nil

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -669,14 +669,19 @@ func (c *collector) CollectMetrics(mts []plugin.Metric) ([]plugin.Metric, error)
 	}
 
 	// add labels as tags to metrics
-
 	for i := range metrics {
 		rid := metrics[i].Namespace[2].Value
+		// adding labels - only for docker's container, skip the host
 		if rid != "root" {
-			// add labels only for docker cointainer, skip the host
-			metrics[i].Tags = c.containers[rid].Specification.Labels
+			if len(metrics[i].Tags) == 0 {
+				metrics[i].Tags = c.containers[rid].Specification.Labels
+			} else {
+				// adding labels one by one to existing tags
+				for lkey, lval := range c.containers[rid].Specification.Labels {
+					metrics[i].Tags[lkey] = lval
+				}
+			}
 		}
-
 	}
 
 	return metrics, nil

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -691,6 +691,19 @@ func (c *collector) CollectMetrics(mts []plugin.Metric) ([]plugin.Metric, error)
 		return nil, fmt.Errorf("No metrics found")
 	}
 
+	// add labels as tags to metrics
+
+	for i := range metrics {
+		rid := metrics[i].Namespace[2].Value
+		if rid != "root" {
+			// add labels only for docker cointainer, skip the host
+			for labelKey, labelValue := range c.containers[rid].Specification.Labels {
+			metrics[i].Tags[labelKey] = labelValue
+			}
+		}
+		
+	}
+
 	return metrics, nil
 }
 

--- a/collector/collector_test.go
+++ b/collector/collector_test.go
@@ -198,6 +198,14 @@ func TestCollectMetrics(t *testing.T) {
 		conf:       map[string]string{},
 	}
 
+	testLabels := func(metrics []plugin.Metric) {
+		Convey("includes all labels as tags", func() {
+			So(metrics[0].Tags["lkey1"], ShouldEqual, "lval1")
+			So(metrics[0].Tags["lkey2"], ShouldEqual, "lval2")
+			So(metrics[0].Tags["lkey3"], ShouldEqual, "lval3")
+		})
+	}
+
 	Convey("return an error when there is no available container", t, func() {
 		mc := new(ClientMock)
 		mc.On("ListContainersAsMap").Return(nil, errors.New("No docker container found"))
@@ -276,6 +284,8 @@ func TestCollectMetrics(t *testing.T) {
 					So(metrics, ShouldNotBeEmpty)
 					So(len(metrics), ShouldEqual, 1)
 					So(metrics[0].Namespace, ShouldResemble, mockMt.Namespace)
+
+					testLabels(metrics)
 				})
 				Convey("for long docker_id", func() {
 					// specify docker id of requested metric type as a long
@@ -286,6 +296,8 @@ func TestCollectMetrics(t *testing.T) {
 					So(metrics, ShouldNotBeEmpty)
 					So(len(metrics), ShouldEqual, 1)
 					So(strings.Join(metrics[0].Namespace.Strings(), "/"), ShouldEqual, "intel/docker/"+mockDockerID+"/stats/cgroups/memory_stats/cache")
+
+					testLabels(metrics)
 				})
 				Convey("for host of docker_id", func() {
 					// specify docker id of requested metric type
@@ -296,6 +308,10 @@ func TestCollectMetrics(t *testing.T) {
 					So(metrics, ShouldNotBeEmpty)
 					So(len(metrics), ShouldEqual, 1)
 					So(strings.Join(metrics[0].Namespace.Strings(), "/"), ShouldEqual, "intel/docker/root/stats/cgroups/memory_stats/cache")
+
+					Convey("labels are empty", func() {
+						So(metrics[0].Tags, ShouldBeEmpty)
+					})
 				})
 			})
 			Convey("return an error when specified docker_id is invalid", func() {
@@ -346,6 +362,9 @@ func TestCollectMetrics(t *testing.T) {
 				So(metrics, ShouldNotBeEmpty)
 				So(len(metrics), ShouldEqual, 1)
 				So(metrics[0].Namespace, ShouldResemble, mockMt.Namespace)
+
+				testLabels(metrics)
+
 			})
 			Convey("return an error when specified cpu_id is invalid", func() {
 				Convey("when cpu_id is out of range", func() {
@@ -424,6 +443,8 @@ func TestCollectMetrics(t *testing.T) {
 				So(metrics, ShouldNotBeEmpty)
 				So(len(metrics), ShouldEqual, 1)
 				So(metrics[0].Namespace, ShouldResemble, mockMt.Namespace)
+
+				testLabels(metrics)
 			})
 			Convey("return an error when specified label is invalid (not exist)", func() {
 				mockMt.Namespace[5].Value = "lkey1_invalid"

--- a/container/cgroupfs/hugetlb.go
+++ b/container/cgroupfs/hugetlb.go
@@ -27,7 +27,6 @@ import (
 	"strings"
 
 	"github.com/docker/go-units"
-
 	"github.com/intelsdi-x/snap-plugin-collector-docker/container"
 )
 


### PR DESCRIPTION
Fixes  #43
Summary of changes:
- Adds information previously available in subnamespace `label` as tags to each metric
- Removed forwarding tags back to framework, because they are readded after collection anyways

How to verify it:
- Try to collect everything and verify each metric has information from labels also exposed in tags

Testing done:
- Unit tests
- Tested locally with just docker
- Have it tested in kubernetes
