### PR TITLE
Fs fix

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -44,7 +44,7 @@ const (
 	// namespace plugin name
 	PLUGIN_NAME = "docker"
 	// version of plugin
-	PLUGIN_VERSION = 6
+	PLUGIN_VERSION = 7
 
 	// each metric starts with prefix "/intel/docker/<docker_id>"
 	lengthOfNsPrefix = 3

--- a/container/fs/types.go
+++ b/container/fs/types.go
@@ -31,6 +31,12 @@ const (
 	VFS          FsType = "vfs"
 )
 
+// Identifies device in system
+type DeviceId struct {
+	Major uint
+	Minor uint
+}
+
 // DeviceInfo holds device name and major and minor numbers
 type DeviceInfo struct {
 	Device string


### PR DESCRIPTION
Fixes #69 

Summary of changes:
- Devices in getDiskStatsMap are identified now by (minor, major) pair instead of device path which is not consistent with other functions referring to same device
- GetGlobalFsInfo changed appropriately

How to verify it:
- Collect filesystem metrics using this plugin and see if output is as expected

Testing done:
- Manual, on bare metal