### PR TITLE
Fixed issue #77: Changed in documentation `total_usage` to `total`

### DIFF
--- a/METRICS.md
+++ b/METRICS.md
@@ -50,7 +50,7 @@ The prefix of metric's namespace is `/intel/docker/<docker_id_or_root>/stats/cgr
 
 Namespace | Data Type | Description
 ----------|-----------|-----------------------
-cpu_stats/cpu_usage/total_usage | uint64 | The total CPU time consumed
+cpu_stats/cpu_usage/total | uint64 | The total CPU time consumed
 cpu_stats/cpu_usage/kernel_mode | uint64 | CPU time consumed by tasks in system (kernel) mode
 cpu_stats/cpu_usage/user_mode | uint64 | CPU time consumed by tasks in user mode
 cpu_stats/cpu_usage/per_cpu/\<N\>/value | uint64 | CPU time consumed on each N-th CPU by all tasks

--- a/README.md
+++ b/README.md
@@ -150,13 +150,13 @@ See  output from snaptel task watch <task_id>
 $ snaptel task watch 02dd7ff4-8106-47e9-8b86-70067cd0a850
 Watching Task (02dd7ff4-8106-47e9-8b86-70067cd0a850):
 NAMESPACE                                                                    DATA      		TIMESTAMP
-/intel/docker/7720efd76bb8/cgroups/cpu_stats/cpu_usage/total_usage           2.146646e+07       2016-06-21 12:44:09.551811277 +0200 CEST
+/intel/docker/7720efd76bb8/cgroups/cpu_stats/cpu_usage/total           2.146646e+07       2016-06-21 12:44:09.551811277 +0200 CEST
 /intel/docker/7720efd76bb8/cgroups/cpu_stats/cpu_usage/kernel_mode           1e+07              2016-06-21 12:44:09.552107446 +0200 CEST
 /intel/docker/7720efd76bb8/cgroups/cpu_stats/cpu_usage/user_mode             0                  2016-06-21 12:44:09.552146203 +0200 CEST
-/intel/docker/ad5221e8ae73/cgroups/cpu_stats/cpu_usage/total_usage           2.146646e+07       2016-06-21 12:44:09.551811277 +0200 CEST
+/intel/docker/ad5221e8ae73/cgroups/cpu_stats/cpu_usage/total           2.146646e+07       2016-06-21 12:44:09.551811277 +0200 CEST
 /intel/docker/ad5221e8ae73/cgroups/cpu_stats/cpu_usage/kernel_mode           1e+07              2016-06-21 12:44:09.552107446 +0200 CEST
 /intel/docker/ad5221e8ae73/cgroups/cpu_stats/cpu_usage/user_mode             0                  2016-06-21 12:44:09.552146203 +0200 CEST
-/intel/docker/root/cgroups/cpu_stats/cpu_usage/total_usage                   2.88984998661e+12  2016-06-21 12:44:09.551811277 +0200 CEST
+/intel/docker/root/cgroups/cpu_stats/cpu_usage/total                   2.88984998661e+12  2016-06-21 12:44:09.551811277 +0200 CEST
 /intel/docker/root/cgroups/cpu_stats/cpu_usage/kernel_mode                   6.38e+11            2016-06-21 12:44:09.552107446 +0200 CEST
 /intel/docker/root/cgroups/cpu_stats/cpu_usage/user_mode                     9.4397e+11          2016-06-21 12:44:09.552146203 +0200 CEST
 ```

--- a/collector/collector_test.go
+++ b/collector/collector_test.go
@@ -77,7 +77,7 @@ var mockMts = []plugin.Metric{
 	plugin.Metric{
 		Namespace: plugin.NewNamespace(PLUGIN_VENDOR, PLUGIN_NAME).
 			AddDynamicElement("docker_id", "an id of docker container").
-			AddStaticElements("stats", "cgroups", "cpu_stats", "cpu_usage", "total_usage"),
+			AddStaticElements("stats", "cgroups", "cpu_stats", "cpu_usage", "total"),
 		Config: metricConf,
 	},
 	plugin.Metric{


### PR DESCRIPTION
Fixed #77 

### Reasoning
Two latest versions of docker collector plugin (8 & 7) both expose metric `cpu_usage/total` as below:
```
/intel/docker/*/stats/cgroups/cpu_stats/cpu_usage/total 
```
Hovewer, documentation and tests hadn't been updated and metric name `cpu_usage/total_usage` was presented as it was for the plugin in version 7.

Based on that, do the same change in README.md, METRICS.md and in tests should happen, what is addressed in this PR.
